### PR TITLE
fix(config): path not defined error

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "tailwindcss-animate": "^1.0.6"
   },
   "devDependencies": {
+    "@types/node": "^20.8.0",
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
     "@typescript-eslint/eslint-plugin": "^5.59.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': resolve(__dirname, './src'),
     },
   },
 });


### PR DESCRIPTION
This error occurred to me when I tried to run the project
![image](https://github.com/dan5py/react-vite-shadcn-ui/assets/86785660/035fd56b-9ae8-4073-8e68-c84e39d9b04a)


So importing resolve from path module fixed the error